### PR TITLE
Add resources for building the docker image and deploying with compose

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,0 +1,31 @@
+FROM ruby:3.2.6
+
+RUN apt-get update -qq && apt-get install -y \
+    build-essential \
+    libpq-dev \
+    postgresql-client \
+    nodejs \
+    curl \
+    tar
+
+# Set working directory
+WORKDIR /app
+
+# Copy the source from the release
+COPY src/. ./.
+
+# Fix for pg error -- error: use of undeclared identifier 'rb_cData'
+RUN bundle update pg
+
+# Install gems
+RUN bundle install
+
+# Precompile assets for production
+RUN bundle exec rake app:assets:precompile
+
+# Expose the Rails default port
+EXPOSE 3000
+
+# Default bash
+CMD ["bash"]
+

--- a/deploy/docker-compose-build.yml
+++ b/deploy/docker-compose-build.yml
@@ -1,0 +1,44 @@
+---
+services:
+  spina:
+    image: localhost/manny-yes/spina:v2.6.2-build
+    build:
+      context: ..
+      dockerfile: deploy/Dockerfile
+    ports:
+      - "3000:3000"
+    depends_on:
+      spinadb:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://${DB_USER}:${DB_PASS}@spinadb:${DB_PORT}/${DB_NAME}
+    command: >
+      bash -c "
+      if [ ! -f db/schema.rb ]; then
+        rails db:create &&
+        rails app:active_storage:install && 
+        rails g spina:install --silent;
+      fi &&
+      rails s -b 0.0.0.0"
+    volumes:
+      - spina-data:/app
+
+  spinadb:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASS}
+      POSTGRES_PORT: ${DB_PORT}
+      POSTGRES_DB: ${DB_NAME}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -p ${DB_PORT}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - spinadb-data:/var/lib/postgresql/data
+
+volumes:
+  spina-data:
+  spinadb-data:
+...

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,41 @@
+---
+services:
+  spina:
+    image: ghcr.io/manny-yes/spina:v2.6.2
+    ports:
+      - "3000:3000"
+    depends_on:
+      spinadb:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://${DB_USER}:${DB_PASS}@spinadb:${DB_PORT}/${DB_NAME}
+    command: >
+      bash -c "
+      if [ ! -f db/schema.rb ]; then
+        rails db:create &&
+        rails app:active_storage:install && 
+        rails g spina:install --silent;
+      fi &&
+      rails s -b 0.0.0.0"
+    volumes:
+      - spina-data:/app
+
+  spinadb:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASS}
+      POSTGRES_PORT: ${DB_PORT}
+      POSTGRES_DB: ${DB_NAME}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -p ${DB_PORT}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - spinadb-data:/var/lib/postgresql/data
+
+volumes:
+  spina-data:
+  spinadb-data:
+...


### PR DESCRIPTION
## Overview

Add the required resources for a docker deploy.

## Changes 

- feat: add dockerfile for building the image
- feat: add compose file with build step embedded for local builds
- feat: add compose file pulling the image from ghcr.io public registry
- feat: add `.env` file to store db secrets and parameters

## Links
- https://docs.docker.com/reference/compose-file/build/